### PR TITLE
Fix all 6 theater scrapers to use correct HTML selectors

### DIFF
--- a/scrape_with_json.py
+++ b/scrape_with_json.py
@@ -21,6 +21,8 @@ from src.scraping.scrapers.ks_cinema_scraper import KsCinemaScraper
 from src.scraping.scrapers.shimotakaido_scraper import ShimotakaidoCinemaScraper
 from src.scraping.scrapers.waseda_shochiku_scraper import WasedaShochikuScraper
 from src.scraping.scrapers.shinjuku_musashino_scraper import ShinjukuMusashinoScraper
+from src.scraping.scrapers.eurospace_scraper import EurospaceScraper
+from src.scraping.scrapers.pole_pole_scraper import PolePoleHigashinakanoScraper
 
 
 def setup_logging(verbose: bool = False):
@@ -56,7 +58,9 @@ def main():
             'ks_cinema': KsCinemaScraper(),
             'shimotakaido': ShimotakaidoCinemaScraper(),
             'waseda_shochiku': WasedaShochikuScraper(),
-            'shinjuku_musashino': ShinjukuMusashinoScraper()
+            'shinjuku_musashino': ShinjukuMusashinoScraper(),
+            'eurospace': EurospaceScraper(),
+            'pole_pole': PolePoleHigashinakanoScraper()
         }
         
         theater_data_list = []

--- a/src/scraping/scrapers/eurospace_scraper.py
+++ b/src/scraping/scrapers/eurospace_scraper.py
@@ -10,295 +10,185 @@ from ..base_scraper import BaseScraper
 from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class EurospaceScraper(BaseScraper):
-    """ユーロスペース スクレイパー"""
-    
+    """ユーロスペース スクレイパー
+
+    注意: https://www.eurospace.co.jp はSSLエラーのため、
+    http://www.eurospace.co.jp を使用する。
+    """
+
     def __init__(self):
         super().__init__(
             theater_name="ユーロスペース",
-            base_url="https://www.eurospace.co.jp"
+            base_url="http://www.eurospace.co.jp"
         )
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        # SSL問題の可能性があるため、Seleniumを使用
-        soup = self.get_page_with_selenium(self.base_url)
-        if not soup:
-            # 基本情報をハードコード
-            return TheaterInfo(
-                name=self.theater_name,
-                url=self.base_url,
-                address="東京都渋谷区円山町1-5 キノハウス地下2階",
-                phone="03-3461-0211",
-                access="JR渋谷駅より徒歩5分",
-                screens=2
-            )
-            
-        # アクセス情報を抽出
-        address = "東京都渋谷区円山町1-5 キノハウス地下2階"
-        phone = "03-3461-0211"
-        access = "JR渋谷駅より徒歩5分"
-        
-        # ページから詳細情報を取得
-        address_elem = soup.find("div", class_="address") or soup.find("p", string=re.compile(r"渋谷区"))
-        if address_elem:
-            address = self.clean_text(address_elem.get_text())
-            
-        phone_elem = soup.find("a", href=re.compile(r"tel:")) or soup.find("div", class_="tel")
-        if phone_elem:
-            phone_text = phone_elem.get("href", "") if phone_elem.name == "a" else phone_elem.get_text()
-            phone = phone_text.replace("tel:", "").strip()
-            
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
-            address=address,
-            phone=phone,
-            access=access,
+            address="東京都渋谷区円山町1-5 キノハウス地下2階",
+            phone="03-3461-0211",
+            access="JR渋谷駅より徒歩5分",
             screens=2
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
+        """映画情報取得
+        トップページ div.item > p > a のリンクから詳細ページへアクセス。
+        詳細ページ(section#workDetail)のh2にタイトル、p.work-captionに監督・出演情報。
+        """
         movies = []
-        
-        # メインページから映画情報取得
-        soup = self.get_page_with_selenium(self.base_url)
-        if soup:
-            movies.extend(self._extract_movies_from_page(soup))
-            
-        # 作品一覧ページも確認
-        works_urls = [
-            f"{self.base_url}/works/",
-            f"{self.base_url}/current/",
-            f"{self.base_url}/coming/"
-        ]
-        
-        for url in works_urls:
-            works_soup = self.get_page_with_selenium(url)
-            if works_soup:
-                movies.extend(self._extract_movies_from_page(works_soup))
-                
-        return movies
-        
-    def _extract_movies_from_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """ページから映画情報抽出"""
-        movies = []
-        
-        # 映画情報を含む要素を検索
-        movie_selectors = [
-            "div.movie-item",
-            "div.work-item",
-            "article.movie",
-            "div.film-info",
-            "section.movie-section"
-        ]
-        
-        movie_elements = []
-        for selector in movie_selectors:
-            elements = soup.select(selector)
-            if elements:
-                movie_elements.extend(elements)
-                
-        # 汎用的な検索も実行
-        if not movie_elements:
-            # h2, h3タグから映画タイトルを推定
-            title_elements = soup.find_all(["h2", "h3"])
-            for elem in title_elements:
-                parent = elem.parent
-                if parent and self._is_movie_element(parent):
-                    movie_elements.append(parent)
-                    
-        for element in movie_elements:
-            movie = self._extract_movie_from_element(element)
-            if movie:
-                movies.append(movie)
-                
-        return movies
-        
-    def _is_movie_element(self, element) -> bool:
-        """要素が映画情報を含むかチェック"""
-        text = element.get_text().lower()
-        movie_indicators = ["監督", "出演", "分", "上映", "劇場", "作品", "映画"]
-        return any(indicator in text for indicator in movie_indicators)
-        
-    def _extract_movie_from_element(self, element) -> Optional[MovieInfo]:
-        """要素から映画情報抽出"""
-        try:
-            # タイトル
-            title_elem = element.find(["h2", "h3", "h4"]) or element.find("div", class_="title")
-            title = self.safe_extract_text(title_elem)
-            
-            if not title:
-                return None
-                
-            # 英語タイトル
-            title_en_elem = element.find("p", class_="title-en") or element.find("div", class_="title-en")
-            title_en = self.safe_extract_text(title_en_elem)
-            
-            # 監督情報
-            director = self._extract_info_by_label(element, "監督")
-            
-            # 出演者情報
-            cast_text = self._extract_info_by_label(element, "出演")
-            cast = [c.strip() for c in cast_text.split(",") if c.strip()] if cast_text else []
-            
-            # 上映時間
-            duration = self._extract_duration(element)
-            
-            # ジャンル
-            genre = self._extract_info_by_label(element, "ジャンル")
-            
-            # あらすじ
-            synopsis_elem = element.find("div", class_="synopsis") or element.find("p", class_="description")
-            synopsis = self.safe_extract_text(synopsis_elem)
-            
-            # ポスター画像
-            poster_elem = element.find("img")
-            poster_url = ""
-            if poster_elem:
-                poster_url = self.safe_extract_attr(poster_elem, "src")
-                if poster_url and not poster_url.startswith("http"):
-                    if poster_url.startswith("//"):
-                        poster_url = f"https:{poster_url}"
-                    else:
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
-            return MovieInfo(
-                title=title,
-                title_en=title_en if title_en else None,
-                director=director if director else None,
-                cast=cast,
-                genre=genre if genre else None,
-                duration=duration,
-                synopsis=synopsis if synopsis else None,
-                poster_url=poster_url if poster_url else None
-            )
-            
-        except Exception as e:
-            self.logger.error(f"Error extracting movie info: {e}")
-            return None
-            
-    def _extract_info_by_label(self, element, label: str) -> str:
-        """ラベルによる情報抽出"""
-        # ラベル付きの情報を検索
-        label_patterns = [
-            f"{label}：",
-            f"{label}:",
-            f"<strong>{label}</strong>",
-            f"<b>{label}</b>"
-        ]
-        
-        text = element.get_text()
-        for pattern in label_patterns:
-            if pattern in text:
-                # パターンの後の文字列を取得
-                parts = text.split(pattern, 1)
-                if len(parts) > 1:
-                    info = parts[1].split("\n")[0].strip()
-                    return info
-                    
-        return ""
-        
-    def _extract_duration(self, element) -> Optional[int]:
-        """上映時間抽出"""
-        text = element.get_text()
-        duration_match = re.search(r"(\d+)分", text)
-        if duration_match:
-            return int(duration_match.group(1))
-        return None
-        
-    def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得"""
-        schedules = []
-        
-        # スケジュールページを取得
-        schedule_urls = [
-            f"{self.base_url}/schedule/",
-            f"{self.base_url}/timetable/"
-        ]
-        
-        for url in schedule_urls:
-            soup = self.get_page_with_selenium(url)
-            if soup:
-                schedules.extend(self._extract_schedules_from_page(soup))
-                
-        return schedules
-        
-    def _extract_schedules_from_page(self, soup: BeautifulSoup) -> List[MovieSchedule]:
-        """ページからスケジュール情報抽出"""
-        schedules = []
-        
-        # スケジュールテーブルを検索
-        schedule_tables = soup.find_all("table", class_="schedule") or soup.find_all("div", class_="schedule")
-        
-        for table in schedule_tables:
+        soup = self.get_page(self.base_url)
+        if not soup:
+            return movies
+
+        # div.itemから映画詳細ページのリンクを収集
+        work_links = []
+        seen_links = set()
+        for item in soup.find_all("div", class_="item"):
+            link = item.find("a")
+            if link:
+                href = link.get("href", "")
+                if href and "/works/detail.php" in href and href not in seen_links:
+                    seen_links.add(href)
+                    full_url = href if href.startswith("http") else f"{self.base_url}{href}"
+                    work_links.append(full_url)
+
+        for url in work_links:
             try:
-                # 映画タイトル
-                title_elem = table.find("h3") or table.find("h2") or table.find("caption")
-                movie_title = self.safe_extract_text(title_elem)
-                
+                movie = self._scrape_movie_detail(url)
+                if movie:
+                    movies.append(movie)
+                self.delay(0.5)
+            except Exception as e:
+                self.logger.error(f"Error scraping movie detail {url}: {e}")
+
+        return movies
+
+    def _scrape_movie_detail(self, url: str) -> Optional[MovieInfo]:
+        """作品詳細ページから映画情報を抽出
+        HTML構造: section#workDetail > h2(タイトル) + p.work-caption(出演・監督等)
+        """
+        soup = self.get_page(url)
+        if not soup:
+            return None
+
+        detail = soup.find("section", id="workDetail")
+        if not detail:
+            return None
+
+        # タイトル
+        title_elem = detail.find("h2")
+        if not title_elem:
+            return None
+        title = title_elem.get_text(strip=True)
+        if not title:
+            return None
+
+        # ポスター画像
+        poster_url = None
+        img_div = detail.find("div", class_="work-image")
+        if img_div:
+            img = img_div.find("img")
+            if img:
+                src = img.get("src", "")
+                if src:
+                    poster_url = src if src.startswith("http") else f"{self.base_url}{src}"
+
+        # 監督・出演情報 (p.work-caption)
+        director = None
+        cast = []
+        duration = None
+        caption = detail.find("p", class_="work-caption")
+        if caption:
+            cap_text = caption.get_text()
+            # 監督（撮影・音楽・出演・脚本・製作などで終わる前の名前のみ）
+            director_match = re.search(r'監督[・脚本]*[：:]?\s*([^撮影出演音楽編集製作配給脚本\n/　・]+?)(?:撮影|出演|音楽|編集|製作|配給|脚本|\n|　|$)', cap_text)
+            if director_match:
+                director = director_match.group(1).strip()
+            # 出演
+            cast_match = re.search(r'出演[：:]\s*([^\n]+)', cap_text)
+            if cast_match:
+                cast_text = cast_match.group(1)
+                cast = [c.strip() for c in re.split(r'[/、,，・ ]', cast_text) if c.strip()]
+            # 上映時間
+            duration_match = re.search(r'(\d+)分', cap_text)
+            if duration_match:
+                duration = int(duration_match.group(1))
+
+        return MovieInfo(
+            title=title,
+            director=director,
+            cast=cast,
+            duration=duration,
+            poster_url=poster_url
+        )
+
+    def get_schedules(self) -> List[MovieSchedule]:
+        """スケジュール情報取得
+        トップページのdiv.scrolltable > table に本日のスケジュールが入っている。
+        tr.time > td で時刻、次のtrのtd > aで映画タイトルを取得。
+        """
+        schedules = []
+        soup = self.get_page(self.base_url)
+        if not soup:
+            return schedules
+
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        # scrolltable内のtableを解析
+        for scrolltable in soup.find_all("div", class_="scrolltable"):
+            table = scrolltable.find("table")
+            if not table:
+                continue
+
+            rows = table.find_all("tr")
+            if not rows:
+                continue
+
+            # 最初のtr.timeに時刻が並んでいる
+            time_row = None
+            movie_row = None
+            for row in rows:
+                if "time" in row.get("class", []):
+                    time_row = row
+                else:
+                    movie_row = row
+
+            if not time_row or not movie_row:
+                continue
+
+            times = [td.get_text(strip=True) for td in time_row.find_all("td")]
+            movie_tds = movie_row.find_all("td")
+
+            # 各tdに映画タイトル+時刻が対応
+            for i, td in enumerate(movie_tds):
+                a = td.find("a")
+                if not a:
+                    continue
+                movie_title = a.get_text(strip=True)
                 if not movie_title:
                     continue
-                    
-                # 上映時間情報
-                showtimes = []
-                
-                # 行ごとに処理
-                rows = table.find_all("tr") if table.name == "table" else table.find_all("div", class_="schedule-row")
-                
-                for row in rows:
-                    # 日付
-                    date_elem = row.find("td", class_="date") or row.find("div", class_="date")
-                    date_text = self.safe_extract_text(date_elem)
-                    
-                    # 時刻
-                    time_elems = row.find_all("td", class_="time") or row.find_all("span", class_="time")
-                    times = [self.safe_extract_text(elem) for elem in time_elems if self.safe_extract_text(elem)]
-                    
-                    if date_text and times:
-                        formatted_date = self._format_date(date_text)
-                        
-                        showtimes.append(ShowtimeInfo(
-                            date=formatted_date,
-                            times=times,
-                            screen="スクリーン1"
-                        ))
-                        
-                if showtimes:
+
+                # 対応する時刻
+                showtime = times[i] if i < len(times) else ""
+
+                # 既存のスケジュールに追加または新規作成
+                existing = next(
+                    (s for s in schedules if s.movie_title == movie_title), None
+                )
+                if existing:
+                    if showtime and showtime not in existing.showtimes[0].times:
+                        existing.showtimes[0].times.append(showtime)
+                else:
                     schedules.append(MovieSchedule(
                         theater_name=self.theater_name,
                         movie_title=movie_title,
-                        showtimes=showtimes
+                        showtimes=[ShowtimeInfo(
+                            date=today,
+                            times=[showtime] if showtime else [],
+                            screen="ユーロスペース"
+                        )]
                     ))
-                    
-            except Exception as e:
-                self.logger.error(f"Error extracting schedule info: {e}")
-                continue
-                
+
         return schedules
-        
-    def _format_date(self, date_text: str) -> str:
-        """日付フォーマット変換"""
-        try:
-            # 様々な日付形式に対応
-            date_patterns = [
-                r"(\d{1,2})/(\d{1,2})",  # MM/DD
-                r"(\d{1,2})月(\d{1,2})日",  # MM月DD日
-                r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
-                r"(\d{1,2})\.(\d{1,2})",  # MM.DD
-            ]
-            
-            for pattern in date_patterns:
-                match = re.search(pattern, date_text)
-                if match:
-                    if len(match.groups()) == 2:
-                        month, day = match.groups()
-                        return f"2024-{int(month):02d}-{int(day):02d}"
-                    elif len(match.groups()) == 3:
-                        year, month, day = match.groups()
-                        return f"{year}-{int(month):02d}-{int(day):02d}"
-                        
-            return date_text
-            
-        except Exception:
-            return date_text

--- a/src/scraping/scrapers/ks_cinema_scraper.py
+++ b/src/scraping/scrapers/ks_cinema_scraper.py
@@ -11,226 +11,156 @@ from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class KsCinemaScraper(BaseScraper):
     """ケイズシネマ スクレイパー"""
-    
+
     def __init__(self):
         super().__init__(
             theater_name="ケイズシネマ",
             base_url="https://www.ks-cinema.com"
         )
         self.schedule_url = f"{self.base_url}/schedule/"
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        soup = self.get_page(self.base_url)
-        if not soup:
-            return TheaterInfo(name=self.theater_name, url=self.base_url)
-            
-        # アクセス情報ページから詳細取得
         access_soup = self.get_page(f"{self.base_url}/access/")
-        
+
         address = ""
         phone = ""
         access = ""
-        
+
         if access_soup:
-            # 住所情報
             address_elem = access_soup.find("div", class_="address")
             if address_elem:
                 address = self.clean_text(address_elem.get_text())
-                
-            # 電話番号
+
             phone_elem = access_soup.find("a", href=re.compile(r"tel:"))
             if phone_elem:
                 phone = phone_elem.get("href").replace("tel:", "")
-                
-            # アクセス情報
+
             access_elem = access_soup.find("div", class_="access-info")
             if access_elem:
                 access = self.clean_text(access_elem.get_text())
-                
+
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
-            address=address,
-            phone=phone,
-            access=access,
-            screens=1  # 基本的に1スクリーン
+            address=address or "東京都新宿区新宿3-13-3",
+            phone=phone or "03-3352-2471",
+            access=access or "JR新宿駅東口より徒歩5分",
+            screens=1
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
         movies = []
-        
-        # 現在上映中の映画
+
         soup = self.get_page(self.base_url)
         if soup:
             movies.extend(self._extract_movies_from_page(soup))
-            
-        # 近日公開の映画
+
         coming_soup = self.get_page(f"{self.base_url}/coming/")
         if coming_soup:
             movies.extend(self._extract_movies_from_page(coming_soup))
-            
+
         return movies
-        
+
     def _extract_movies_from_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """ページから映画情報抽出"""
+        """ページから映画情報抽出
+        HTML構造: div.movielist > div.box.clearfix > (h3タイトル + div.movietxt + img)
+        """
         movies = []
-        
-        # ケイズシネマの実際の構造に合わせて修正
+
         movielist = soup.find("div", class_="movielist")
         if not movielist:
             return movies
-            
-        # div.box clearfix が個別の映画情報
+
         movie_boxes = movielist.find_all("div", class_="box")
-        
+
+        seen_titles = set()
         for box in movie_boxes:
             try:
-                # movietxt内のテキストから情報を抽出
-                movietxt = box.find("div", class_="movietxt")
-                if not movietxt:
+                # h3タグからタイトル取得
+                title_elem = box.find("h3")
+                if not title_elem:
                     continue
-                
-                # 全テキストを取得
-                full_text = movietxt.get_text(strip=True)
-                if not full_text:
+
+                title = title_elem.get_text(strip=True)
+                if not title or title in seen_titles:
                     continue
-                
-                # タイトルを抽出（最初の行から時刻を除外）
-                title_line = full_text.split('\n')[0].strip()
-                
-                # 時刻パターンを除去してタイトルを抽出
-                title = re.sub(r'\d{1,2}:\d{2}', '', title_line).strip()
-                
-                # 特殊なケースの処理
-                if '作品案内参照' in title:
-                    # 特別上映などの場合はスキップするか簡略化
-                    continue
-                
-                if not title:
-                    continue
-                
-                # 上映時間を抽出
-                times = re.findall(r'\d{1,2}:\d{2}', full_text)
-                
-                # 基本的な映画情報を作成
-                title_en = None
-                director = None
-                cast = []
-                duration = None
-                synopsis = None
-                
+
+                seen_titles.add(title)
+
                 # ポスター画像
-                poster_elem = box.find("img")
-                poster_url = ""
-                if poster_elem:
-                    poster_url = self.safe_extract_attr(poster_elem, "src")
-                    if poster_url and not poster_url.startswith("http"):
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
+                poster_url = None
+                img = box.find("img")
+                if img:
+                    src = img.get("src", "")
+                    if src:
+                        poster_url = src if src.startswith("http") else f"{self.base_url}{src}"
+
                 movies.append(MovieInfo(
                     title=title,
-                    title_en=title_en if title_en else None,
-                    director=director if director else None,
-                    cast=cast,
-                    duration=duration,
-                    synopsis=synopsis if synopsis else None,
-                    poster_url=poster_url if poster_url else None
+                    poster_url=poster_url
                 ))
-                
+
             except Exception as e:
                 self.logger.error(f"Error extracting movie info: {e}")
                 continue
-                
+
         return movies
-        
+
     def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得"""
         schedules = []
-        
-        # メインページから情報を取得（ケイズシネマはメインページにスケジュールがある）
+
         soup = self.get_page(self.base_url)
         if not soup:
             return schedules
-        
+
         movielist = soup.find("div", class_="movielist")
         if not movielist:
             return schedules
-            
-        # div.box clearfix からスケジュール情報を抽出
+
         movie_boxes = movielist.find_all("div", class_="box")
-        
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        seen_titles = set()
         for box in movie_boxes:
             try:
-                # movietxt内のテキストから情報を抽出
+                title_elem = box.find("h3")
+                if not title_elem:
+                    continue
+
+                movie_title = title_elem.get_text(strip=True)
+                if not movie_title:
+                    continue
+
                 movietxt = box.find("div", class_="movietxt")
                 if not movietxt:
                     continue
-                
-                # 全テキストを取得
-                full_text = movietxt.get_text(strip=True)
-                if not full_text:
+
+                full_text = movietxt.get_text()
+
+                # 「作品案内参照」の場合は時刻なしとして扱う
+                if "作品案内参照" in full_text:
+                    times = []
+                else:
+                    times = re.findall(r'\d{1,2}:\d{2}', full_text)
+
+                if movie_title in seen_titles:
                     continue
-                
-                # タイトルを抽出
-                title_line = full_text.split('\n')[0].strip()
-                movie_title = re.sub(r'\d{1,2}:\d{2}', '', title_line).strip()
-                
-                # 特殊なケースをスキップ
-                if '作品案内参照' in movie_title:
-                    continue
-                
-                if not movie_title:
-                    continue
-                
-                # 上映時間を抽出
-                times = re.findall(r'\d{1,2}:\d{2}', full_text)
-                
-                if times:
-                    # 今日の日付でスケジュール作成（実際のサイトでは日付情報が限定的）
-                    from datetime import datetime
-                    today = datetime.now().strftime("%Y-%m-%d")
-                    
-                    showtimes = [ShowtimeInfo(
-                        date=today,
-                        times=times,
-                        screen="スクリーン1"
-                    )]
-                    
-                    schedules.append(MovieSchedule(
-                        theater_name=self.theater_name,
-                        movie_title=movie_title,
-                        showtimes=showtimes
-                    ))
-                    
+                seen_titles.add(movie_title)
+
+                showtimes = [ShowtimeInfo(
+                    date=today,
+                    times=times,
+                    screen="スクリーン1"
+                )]
+
+                schedules.append(MovieSchedule(
+                    theater_name=self.theater_name,
+                    movie_title=movie_title,
+                    showtimes=showtimes
+                ))
+
             except Exception as e:
                 self.logger.error(f"Error extracting schedule info: {e}")
                 continue
-                
+
         return schedules
-        
-    def _format_date(self, date_text: str) -> str:
-        """日付フォーマット変換"""
-        try:
-            # 様々な日付形式に対応
-            date_patterns = [
-                r"(\d{1,2})/(\d{1,2})",  # MM/DD
-                r"(\d{1,2})月(\d{1,2})日",  # MM月DD日
-                r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
-            ]
-            
-            for pattern in date_patterns:
-                match = re.search(pattern, date_text)
-                if match:
-                    if len(match.groups()) == 2:
-                        month, day = match.groups()
-                        return f"2024-{int(month):02d}-{int(day):02d}"
-                    elif len(match.groups()) == 3:
-                        year, month, day = match.groups()
-                        return f"{year}-{int(month):02d}-{int(day):02d}"
-                        
-            return date_text
-            
-        except Exception:
-            return date_text

--- a/src/scraping/scrapers/pole_pole_scraper.py
+++ b/src/scraping/scrapers/pole_pole_scraper.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 from datetime import datetime
 import re
-import json
 from bs4 import BeautifulSoup
 import sys
 import os
@@ -11,304 +10,181 @@ from ..base_scraper import BaseScraper
 from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class PolePoleHigashinakanoScraper(BaseScraper):
-    """ポレポレ東中野 スクレイパー"""
-    
+    """ポレポレ東中野 スクレイパー
+
+    Nuxt.js SPAのためSeleniumを使用する。
+    スケジュールはdiv.movie-schedule-info.flex-row に含まれる。
+    デフォルトで本日選択されている日付のスケジュールを取得する。
+    """
+
     def __init__(self):
         super().__init__(
             theater_name="ポレポレ東中野",
             base_url="https://pole2.co.jp"
         )
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        # Nuxt.jsアプリケーションのため、Seleniumを使用
-        soup = self.get_page_with_selenium(self.base_url)
-        if not soup:
-            return TheaterInfo(name=self.theater_name, url=self.base_url)
-            
-        # アクセス情報
-        access_soup = self.get_page_with_selenium(f"{self.base_url}/access")
-        
-        address = "東京都中野区東中野4-4-1 ポレポレ坐ビル地下"
-        phone = "03-3371-0088"
-        access = "JR中央線・総武線・都営大江戸線東中野駅より徒歩1分"
-        
-        if access_soup:
-            # 詳細情報があれば更新
-            address_elem = access_soup.find("div", class_="address")
-            if address_elem:
-                address = self.clean_text(address_elem.get_text())
-                
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
-            address=address,
-            phone=phone,
-            access=access,
-            screens=2
+            address="東京都中野区東中野4-4-1 ポレポレ坐ビル地下",
+            phone="03-3371-0088",
+            access="JR中央線・総武線・都営大江戸線東中野駅より徒歩1分",
+            screens=1
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
+        """映画情報取得（Seleniumでレンダリングしてから解析）"""
         movies = []
-        
-        # メインページから映画情報取得
-        soup = self.get_page_with_selenium(self.base_url)
+        soup = self._get_rendered_page(self.base_url)
         if soup:
-            movies.extend(self._extract_movies_from_main_page(soup))
-            
-        # 作品一覧ページも確認
-        works_soup = self.get_page_with_selenium(f"{self.base_url}/works")
-        if works_soup:
-            movies.extend(self._extract_movies_from_works_page(works_soup))
-            
+            movies.extend(self._extract_movies_from_schedule(soup))
         return movies
-        
-    def _extract_movies_from_main_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """メインページから映画情報抽出（Nuxt.jsレンダリング後）"""
-        movies = []
-        
-        # Seleniumで取得したページからテキストを解析
-        body_text = soup.get_text()
-        
-        # 映画タイトルをテキストから抽出
-        lines = body_text.split('\n')
-        movie_titles = []
-        
-        # スケジュール部分から映画タイトルを抽出
-        in_schedule_section = False
-        for line in lines:
-            line = line.strip()
-            
-            if '上映スケジュール' in line:
-                in_schedule_section = True
-                continue
-            
-            if in_schedule_section and line:
-                # 日付やその他の情報をスキップして映画タイトルを抽出
-                if not any(keyword in line for keyword in [
-                    '月', '火', '水', '木', '金', '土', '日',
-                    'ポレポレ東中野', '座席表', '購入', '2D', '字幕',
-                    'もっとみる', ':', '〜'
-                ]) and len(line) > 3 and not line.isdigit():
-                    # レーティングや記号を除去
-                    clean_title = re.sub(r'\s*[GR12+]\s*$', '', line)
-                    clean_title = re.sub(r'【.*?】', '', clean_title)
-                    clean_title = clean_title.strip()
-                    
-                    if clean_title and clean_title not in movie_titles:
-                        movie_titles.append(clean_title)
-        
-        # MovieInfoオブジェクトを作成
-        for title in movie_titles:
-            movies.append(MovieInfo(
-                title=title,
-                title_en=None,
-                director=None,
-                cast=[],
-                duration=None,
-                synopsis=None,
-                poster_url=None
-            ))
-                    
-        return movies
-        
-    def _extract_movies_from_works_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """作品ページから映画情報抽出"""
-        movies = []
-        
-        movie_cards = soup.find_all("div", class_="work-card") or soup.find_all("div", class_="movie-card")
-        
-        for card in movie_cards:
-            movie = self._extract_movie_from_element(card)
-            if movie:
-                movies.append(movie)
-                
-        return movies
-        
-    def _extract_movie_from_element(self, element) -> Optional[MovieInfo]:
-        """要素から映画情報抽出"""
+
+    def _get_rendered_page(self, url: str, wait_seconds: int = 5) -> Optional[BeautifulSoup]:
+        """Seleniumでページを取得してBeautifulSoupを返す"""
+        import time
+        from selenium import webdriver
+        from selenium.webdriver.chrome.options import Options
+
+        options = Options()
+        options.add_argument('--headless')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument('--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36')
+
+        driver = None
         try:
-            # タイトル
-            title_elem = element.find("h2") or element.find("h3") or element.find("div", class_="title")
-            title = self.safe_extract_text(title_elem)
-            
-            if not title:
-                return None
-                
-            # 英語タイトル
-            title_en_elem = element.find("p", class_="title-en") or element.find("div", class_="title-en")
-            title_en = self.safe_extract_text(title_en_elem)
-            
-            # 監督
-            director_elem = element.find("div", class_="director") or element.find("p", class_="director")
-            director = self.safe_extract_text(director_elem)
-            if director.startswith("監督："):
-                director = director[3:]
-                
-            # 出演者
-            cast_elem = element.find("div", class_="cast") or element.find("p", class_="cast")
-            cast_text = self.safe_extract_text(cast_elem)
-            if cast_text.startswith("出演："):
-                cast_text = cast_text[3:]
-            cast = [c.strip() for c in cast_text.split(",") if c.strip()] if cast_text else []
-            
-            # 上映時間
-            duration_elem = element.find("div", class_="duration") or element.find("span", class_="runtime")
-            duration = None
-            if duration_elem:
-                duration_text = self.safe_extract_text(duration_elem)
-                duration_match = re.search(r"(\d+)分", duration_text)
-                if duration_match:
-                    duration = int(duration_match.group(1))
-                    
-            # ジャンル
-            genre_elem = element.find("div", class_="genre") or element.find("span", class_="genre")
-            genre = self.safe_extract_text(genre_elem)
-            
-            # あらすじ
-            synopsis_elem = element.find("div", class_="synopsis") or element.find("p", class_="description")
-            synopsis = self.safe_extract_text(synopsis_elem)
-            
-            # ポスター画像
-            poster_elem = element.find("img")
-            poster_url = ""
-            if poster_elem:
-                poster_url = self.safe_extract_attr(poster_elem, "src")
-                if poster_url and not poster_url.startswith("http"):
-                    if poster_url.startswith("//"):
-                        poster_url = f"https:{poster_url}"
-                    else:
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
-            return MovieInfo(
-                title=title,
-                title_en=title_en if title_en else None,
-                director=director if director else None,
-                cast=cast,
-                genre=genre if genre else None,
-                duration=duration,
-                synopsis=synopsis if synopsis else None,
-                poster_url=poster_url if poster_url else None
-            )
-            
+            driver = webdriver.Chrome(options=options)
+            driver.get(url)
+            time.sleep(wait_seconds)
+            html = driver.page_source
+            return BeautifulSoup(html, 'html.parser')
         except Exception as e:
-            self.logger.error(f"Error extracting movie info: {e}")
+            self.logger.error(f"Selenium error for {url}: {e}")
             return None
-            
+        finally:
+            if driver:
+                driver.quit()
+
+    def _extract_movies_from_schedule(self, soup: BeautifulSoup) -> List[MovieInfo]:
+        """div.movie-schedule-info から映画情報を抽出
+        HTML構造:
+          div.movie-schedule-info.flex-row
+            div.movie-name > span (タイトル)
+            img.movie-image (ポスター)
+        """
+        movies = []
+        seen_titles = set()
+
+        for row in soup.find_all("div", class_="movie-schedule-info flex-row"):
+            try:
+                # タイトル
+                name_div = row.find("div", class_="movie-name")
+                if not name_div:
+                    continue
+                span = name_div.find("span")
+                if not span:
+                    continue
+                title = span.get_text(strip=True)
+                if not title or title in seen_titles:
+                    continue
+                seen_titles.add(title)
+
+                # ポスター画像
+                poster_url = None
+                img = row.find("img", class_="movie-image")
+                if img:
+                    src = img.get("src", "")
+                    if src:
+                        poster_url = src
+
+                movies.append(MovieInfo(
+                    title=title,
+                    poster_url=poster_url
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting movie info: {e}")
+                continue
+
+        return movies
+
     def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得（テキスト解析）"""
+        """スケジュール情報取得
+        div.movie-schedule-head の p.date で本日日付を取得し、
+        div.movie-schedule-body の各 div.movie-schedule-info から
+        タイトル・開始時刻を取得する。
+        """
         schedules = []
-        
-        # メインページから取得（スケジュール情報が含まれている）
-        soup = self.get_page_with_selenium(self.base_url)
+        soup = self._get_rendered_page(self.base_url)
         if not soup:
             return schedules
-        
-        body_text = soup.get_text()
-        lines = body_text.split('\n')
-        
-        # スケジュール情報をパース
-        current_movie = None
-        current_date = None
-        current_times = []
-        
-        for line in lines:
-            line = line.strip()
-            if not line:
+
+        # 選択中の日付を取得（swiper-slide-activeのp.date）
+        active_date = self._get_active_date(soup)
+        today = active_date or datetime.now().strftime("%Y-%m-%d")
+
+        for row in soup.find_all("div", class_="movie-schedule-info flex-row"):
+            try:
+                # タイトル
+                name_div = row.find("div", class_="movie-name")
+                if not name_div:
+                    continue
+                span = name_div.find("span")
+                if not span:
+                    continue
+                title = span.get_text(strip=True)
+                if not title:
+                    continue
+
+                # 開始時刻（div.time > h2）
+                time_div = row.find("div", class_="time")
+                start_time = ""
+                if time_div:
+                    h2 = time_div.find("h2")
+                    if h2:
+                        start_time = h2.get_text(strip=True).replace("~", "").strip()
+
+                # スクリーン情報
+                room_div = row.find("div", class_="room")
+                screen = "ポレポレ東中野（地下）"
+                if room_div:
+                    name_p = room_div.find("p", class_="name")
+                    if name_p:
+                        screen = name_p.get_text(strip=True)
+
+                schedules.append(MovieSchedule(
+                    theater_name=self.theater_name,
+                    movie_title=title,
+                    showtimes=[ShowtimeInfo(
+                        date=today,
+                        times=[start_time] if start_time else [],
+                        screen=screen
+                    )]
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting schedule info: {e}")
                 continue
-            
-            # 日付の検出 (MM/DD形式)
-            date_match = re.match(r'(\d{2})/(\d{2})', line)
-            if date_match:
-                # 前の映画のスケジュールを保存
-                if current_movie and current_times:
-                    schedules.append(MovieSchedule(
-                        theater_name=self.theater_name,
-                        movie_title=current_movie,
-                        showtimes=[ShowtimeInfo(
-                            date=current_date,
-                            times=current_times,
-                            screen="ポレポレ東中野（地下）"
-                        )]
-                    ))
-                
-                # 新しい日付
-                month, day = date_match.groups()
-                current_date = f"2025-{month}-{day}"
-                current_times = []
-                continue
-            
-            # 映画タイトルの検出（特定の除外条件）
-            if (line and 
-                len(line) > 3 and
-                not any(keyword in line for keyword in [
-                    '月', '火', '水', '木', '金', '土', '日',
-                    'ポレポレ東中野', '座席表', '購入', '2D', '字幕',
-                    'もっとみる', ':', '〜', 'バリアフリー'
-                ]) and 
-                not line.isdigit() and
-                not re.match(r'^\d{1,2}:\d{2}', line)):
-                
-                # 前の映画のスケジュールを保存
-                if current_movie and current_times and current_date:
-                    schedules.append(MovieSchedule(
-                        theater_name=self.theater_name,
-                        movie_title=current_movie,
-                        showtimes=[ShowtimeInfo(
-                            date=current_date,
-                            times=current_times,
-                            screen="ポレポレ東中野（地下）"
-                        )]
-                    ))
-                
-                # 新しい映画
-                current_movie = re.sub(r'\s*[GR12+]\s*$', '', line)
-                current_movie = re.sub(r'【.*?】', '', current_movie).strip()
-                current_times = []
-                continue
-            
-            # 時刻の検出
-            time_match = re.match(r'^(\d{1,2}:\d{2})$', line)
-            if time_match and current_movie:
-                current_times.append(time_match.group(1))
-        
-        # 最後の映画のスケジュールを保存
-        if current_movie and current_times and current_date:
-            schedules.append(MovieSchedule(
-                theater_name=self.theater_name,
-                movie_title=current_movie,
-                showtimes=[ShowtimeInfo(
-                    date=current_date,
-                    times=current_times,
-                    screen="ポレポレ東中野（地下）"
-                )]
-            ))
-        
+
         return schedules
-        
-    def _format_date(self, date_text: str) -> str:
-        """日付フォーマット変換"""
-        try:
-            # 様々な日付形式に対応
-            date_patterns = [
-                r"(\d{1,2})/(\d{1,2})",  # MM/DD
-                r"(\d{1,2})月(\d{1,2})日",  # MM月DD日
-                r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
-                r"(\d{1,2})\.(\d{1,2})",  # MM.DD
-            ]
-            
-            for pattern in date_patterns:
-                match = re.search(pattern, date_text)
-                if match:
-                    if len(match.groups()) == 2:
-                        month, day = match.groups()
-                        return f"2024-{int(month):02d}-{int(day):02d}"
-                    elif len(match.groups()) == 3:
-                        year, month, day = match.groups()
-                        return f"{year}-{int(month):02d}-{int(day):02d}"
-                        
-            return date_text
-            
-        except Exception:
-            return date_text
+
+    def _get_active_date(self, soup: BeautifulSoup) -> Optional[str]:
+        """スケジュールカレンダーのアクティブな日付を取得"""
+        active_item = soup.find("div", class_="calender-head-item active")
+        if not active_item:
+            return None
+
+        date_p = active_item.find("p", class_="date")
+        if not date_p:
+            return None
+
+        date_text = date_p.get_text(strip=True)
+        match = re.match(r'(\d{2})/(\d{2})', date_text)
+        if match:
+            year = datetime.now().year
+            month, day = int(match.group(1)), int(match.group(2))
+            return f"{year}-{month:02d}-{day:02d}"
+
+        return None

--- a/src/scraping/scrapers/shimotakaido_scraper.py
+++ b/src/scraping/scrapers/shimotakaido_scraper.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from datetime import datetime
 import re
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, Comment, Tag
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -11,16 +11,14 @@ from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class ShimotakaidoCinemaScraper(BaseScraper):
     """下高井戸シネマ スクレイパー"""
-    
+
     def __init__(self):
         super().__init__(
             theater_name="下高井戸シネマ",
             base_url="http://shimotakaidocinema.com"
         )
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        # 基本情報を返す（実際のサイトにアクセス情報は少ない）
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
@@ -29,380 +27,145 @@ class ShimotakaidoCinemaScraper(BaseScraper):
             access="京王線下高井戸駅より徒歩3分",
             screens=1
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
         movies = []
-        
-        # メインページから映画情報取得
         soup = self.get_page(self.base_url)
         if soup:
             movies.extend(self._extract_movies_from_page(soup))
-            
         return movies
-        
+
     def _extract_movies_from_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """ページから映画情報抽出"""
+        """ページから映画情報抽出
+        HTML構造:
+          ul.slider > li.float > a > img + p.top_jouei
+            p.top_jouei > span.eiga-title (タイトル) + span.day (日程・時刻)
+        """
         movies = []
-        
-        # 下高井戸シネマサイトから映画タイトルを抽出
-        # タイトルは大きなフォントで表示されている
-        body_text = soup.get_text()
-        
-        # 既知の映画タイトルパターンを検索
-        lines = body_text.split('\n')
-        movie_titles = []
-        
-        for line in lines:
-            line = line.strip()
-            # 映画タイトルらしい行を特定
-            if (line and 
-                len(line) > 2 and 
-                not any(skip in line for skip in [
-                    '年', '月', '日', '時', '分', '～', ':', 
-                    'http', 'www', '.com', '@', 'トップ',
-                    'お知らせ', '上映', '開催', 'トーク', '監督',
-                    '先着', 'プレゼント', '決定', '追加'
-                ]) and
-                not line.isdigit() and
-                not re.match(r'^\d{1,2}[/:\-]\d{1,2}', line) and
-                not re.match(r'^(終|開)', line) and
-                len(line) < 50):  # 長すぎる行は除外
-                
-                # 特定の映画タイトルパターンを検出
-                if any(char in line for char in ['！', '？', '♪', '☆']) or \
-                   re.search(r'[ァ-ヴ]+', line) or \
-                   re.search(r'[A-Za-z]{2,}', line):
-                    
-                    # 重複チェック
-                    if line not in movie_titles:
-                        movie_titles.append(line)
-        
-        # 明示的に映画タイトルを抽出（実際のサイトから観察したもの）
-        known_movies = [
-            "旅するローマ教皇",
-            "ドマーニ！愛のことづて", 
-            "シンシン／SING SING",
-            "カップルズ 4Kレストア版",
-            "井口奈己監督特集"
-        ]
-        
-        for known_movie in known_movies:
-            if known_movie in body_text and known_movie not in movie_titles:
-                movie_titles.append(known_movie)
-        
-        # MovieInfoオブジェクトを作成
-        for title in movie_titles[:10]:  # 最大10作品
-            movies.append(MovieInfo(
-                title=title,
-                title_en=None,
-                director=None,
-                cast=[],
-                duration=None,
-                synopsis=None,
-                poster_url=None
-            ))
-                    
+        seen_titles = set()
+
+        for li in soup.find_all("li", class_="float"):
+            try:
+                title_elem = li.find("span", class_="eiga-title")
+                if not title_elem:
+                    continue
+
+                # ブロック要素(br, font)を除いてタイトルを取得
+                title = self._extract_title_text(title_elem)
+                if not title or title in seen_titles:
+                    continue
+                seen_titles.add(title)
+
+                # ポスター画像
+                poster_url = None
+                img = li.find("img")
+                if img:
+                    src = img.get("src", "")
+                    if src:
+                        poster_url = src if src.startswith("http") else f"{self.base_url}/{src}"
+
+                movies.append(MovieInfo(
+                    title=title,
+                    poster_url=poster_url
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting movie info: {e}")
+                continue
+
         return movies
-        
-    def _extract_movies_from_items_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """アイテムページから映画情報抽出"""
-        movies = []
-        
-        # Storesサイトの商品一覧
-        item_cards = soup.find_all("div", class_="item-card") or soup.find_all("div", class_="product-card")
-        
-        for card in item_cards:
-            movie = self._extract_movie_from_element(card)
-            if movie:
-                movies.append(movie)
-                
-        return movies
-        
-    def _extract_movie_from_element(self, element) -> Optional[MovieInfo]:
-        """要素から映画情報抽出"""
-        try:
-            # タイトル
-            title_elem = (element.find("h2") or element.find("h3") or 
-                         element.find("div", class_="title") or 
-                         element.find("a", class_="item-title"))
-            title = self.safe_extract_text(title_elem)
-            
-            if not title:
-                return None
-                
-            # 英語タイトル
-            title_en_elem = element.find("p", class_="title-en") or element.find("div", class_="subtitle")
-            title_en = self.safe_extract_text(title_en_elem)
-            
-            # 説明文から監督・出演者情報を抽出
-            description_elem = element.find("div", class_="description") or element.find("p", class_="item-description")
-            description = self.safe_extract_text(description_elem)
-            
-            director = ""
-            cast = []
-            genre = ""
-            synopsis = ""
-            
-            if description:
-                # 監督情報
-                director_match = re.search(r"監督[：:]([^/\n]+)", description)
-                if director_match:
-                    director = director_match.group(1).strip()
-                    
-                # 出演者情報
-                cast_match = re.search(r"出演[：:]([^/\n]+)", description)
-                if cast_match:
-                    cast_text = cast_match.group(1).strip()
-                    cast = [c.strip() for c in cast_text.split(",") if c.strip()]
-                    
-                # ジャンル
-                genre_match = re.search(r"ジャンル[：:]([^/\n]+)", description)
-                if genre_match:
-                    genre = genre_match.group(1).strip()
-                    
-                # あらすじ（説明文をそのまま使用）
-                synopsis = description
-                
-            # 上映時間
-            duration = None
-            if description:
-                duration_match = re.search(r"(\d+)分", description)
-                if duration_match:
-                    duration = int(duration_match.group(1))
-                    
-            # ポスター画像
-            poster_elem = element.find("img")
-            poster_url = ""
-            if poster_elem:
-                poster_url = self.safe_extract_attr(poster_elem, "src")
-                if poster_url and not poster_url.startswith("http"):
-                    if poster_url.startswith("//"):
-                        poster_url = f"https:{poster_url}"
-                    else:
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
-            return MovieInfo(
-                title=title,
-                title_en=title_en if title_en else None,
-                director=director if director else None,
-                cast=cast,
-                genre=genre if genre else None,
-                duration=duration,
-                synopsis=synopsis if synopsis else None,
-                poster_url=poster_url if poster_url else None
-            )
-            
-        except Exception as e:
-            self.logger.error(f"Error extracting movie info: {e}")
-            return None
-            
+
+    def _extract_title_text(self, title_elem) -> str:
+        """span.eiga-titleからタイトルテキストを抽出
+        メインタイトル + サブタイトル（fontタグ内）を結合する。
+        """
+        parts = []
+        for content in title_elem.contents:
+            if isinstance(content, Comment):
+                continue
+            elif isinstance(content, NavigableString):
+                text = str(content).strip()
+                if text:
+                    parts.append(text)
+            elif isinstance(content, Tag):
+                if content.name == 'br':
+                    continue
+                elif content.name == 'font':
+                    sub = content.get_text(strip=True)
+                    # 注釈系テキストは除外（HELLO!MOVIEなど）
+                    if sub and not sub.startswith('＊') and not sub.startswith('*') and '対応' not in sub:
+                        parts.append(sub)
+
+        return " ".join(parts).strip()
+
     def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得"""
         schedules = []
-        
-        # メインページからスケジュール情報取得
         soup = self.get_page(self.base_url)
         if soup:
             schedules.extend(self._extract_schedules_from_page(soup))
-                
         return schedules
-        
+
     def _extract_schedules_from_page(self, soup: BeautifulSoup) -> List[MovieSchedule]:
-        """ページからスケジュール情報抽出"""
+        """ページからスケジュール情報抽出
+        HTML構造:
+          li.float > a > p.top_jouei
+            span.eiga-title: タイトル
+            span.day: 「MM/DD(曜)～MM/DD(曜)\nHH：MM～(終HH：MM)」
+        """
         schedules = []
-        
-        # 下高井戸シネマサイトのスケジュール解析
-        body_text = soup.get_text()
-        
-        # 既知の映画と上映時間のパターンを解析
-        schedule_patterns = [
-            (r"旅するローマ教皇\s*.*?(\d{1,2}/\d{1,2}\(.\)～\d{1,2}/\d{1,2}\(.\))\s+(\d{1,2}:\d{2}～)", "旅するローマ教皇"),
-            (r"ドマーニ！愛のことづて\s*.*?(\d{1,2}/\d{1,2}\(.\)～\d{1,2}/\d{1,2}\(.\))\s*(\d{1,2}：\d{2}～)", "ドマーニ！愛のことづて"),
-            (r"シンシン／SING SING\s*.*?(\d{1,2}/\d{1,2}\(.\)～\d{1,2}/\d{1,2}\(.\))\s*(\d{1,2}:\d{2}～)", "シンシン／SING SING"),
-            (r"カップルズ 4Kレストア版\s*.*?(\d{1,2}/\d{1,2}\(.\)～\d{1,2}/\d{1,2}\(.\))\s*(\d{1,2}:\d{2}～)", "カップルズ 4Kレストア版"),
-            (r"井口奈己監督特集.*?(\d{1,2}/\d{1,2}\(.\)～\d{1,2}/\d{1,2}\(.\))\s*(\d{1,2}:\d{2})", "井口奈己監督特集")
-        ]
-        
-        for pattern, movie_title in schedule_patterns:
-            matches = re.findall(pattern, body_text, re.DOTALL | re.IGNORECASE)
-            for match in matches:
-                if len(match) >= 2:
-                    date_range = match[0]
-                    showtime = match[1]
-                    
-                    # 日付範囲から開始日を抽出
-                    date_match = re.search(r'(\d{1,2})/(\d{1,2})', date_range)
-                    if date_match:
-                        month, day = date_match.groups()
-                        formatted_date = f"2025-{int(month):02d}-{int(day):02d}"
-                        
-                        # 時間を正規化
-                        time_normalized = showtime.replace('：', ':').replace('～', '').strip()
-                        
-                        schedules.append(MovieSchedule(
-                            theater_name=self.theater_name,
-                            movie_title=movie_title,
-                            showtimes=[ShowtimeInfo(
-                                date=formatted_date,
-                                times=[time_normalized],
-                                screen="スクリーン1"
-                            )]
-                        ))
-        
-        # フォールバック: テキストから時間パターンを検索
-        if not schedules:
-            # より一般的なスケジュールパターン検索
-            lines = body_text.split('\n')
-            current_movie = None
-            
-            for i, line in enumerate(lines):
-                line = line.strip()
-                
-                # 映画タイトルを検出
-                if (line and len(line) > 3 and len(line) < 30 and
-                    not any(skip in line for skip in ['年', '月', '日', '時', '～', ':', 'お知らせ', 'トーク']) and
-                    (any(char in line for char in ['！', '？', '♪', '☆']) or 
-                     re.search(r'[A-Za-z]{2,}', line) or
-                     re.search(r'[ァ-ヴ]+', line))):
-                    current_movie = line
-                
-                # スケジュール情報を検出
-                if current_movie and re.search(r'\d{1,2}/\d{1,2}.*?\d{1,2}:\d{2}', line):
-                    # 日付と時間を抽出
-                    date_match = re.search(r'(\d{1,2})/(\d{1,2})', line)
-                    time_matches = re.findall(r'(\d{1,2}:\d{2})', line)
-                    
-                    if date_match and time_matches:
-                        month, day = date_match.groups()
-                        formatted_date = f"2025-{int(month):02d}-{int(day):02d}"
-                        
-                        schedules.append(MovieSchedule(
-                            theater_name=self.theater_name,
-                            movie_title=current_movie,
-                            showtimes=[ShowtimeInfo(
-                                date=formatted_date,
-                                times=time_matches,
-                                screen="スクリーン1"
-                            )]
-                        ))
-                        current_movie = None  # リセット
-                
-        return schedules
-        
-    def _extract_schedules_from_item_page(self, soup: BeautifulSoup) -> List[MovieSchedule]:
-        """アイテムページからスケジュール情報抽出"""
-        schedules = []
-        
-        # 映画タイトル
-        title_elem = soup.find("h1") or soup.find("h2", class_="item-title")
-        movie_title = self.safe_extract_text(title_elem)
-        
-        if not movie_title:
-            return schedules
-            
-        # 説明文からスケジュール情報を抽出
-        description_elem = soup.find("div", class_="item-description") or soup.find("div", class_="description")
-        description = self.safe_extract_text(description_elem)
-        
-        if description:
-            showtimes = self._extract_showtimes_from_text(description)
-            
-            if showtimes:
+
+        for li in soup.find_all("li", class_="float"):
+            try:
+                title_elem = li.find("span", class_="eiga-title")
+                if not title_elem:
+                    continue
+                title = self._extract_title_text(title_elem)
+                if not title:
+                    continue
+
+                day_elem = li.find("span", class_="day")
+                if not day_elem:
+                    continue
+
+                day_text = day_elem.get_text(separator="\n", strip=True)
+                # 全角コロンを半角に正規化
+                day_text = day_text.replace('：', ':')
+
+                # 日付範囲を抽出: MM/DD(曜)～MM/DD(曜)
+                date_range_match = re.search(
+                    r'(\d{1,2})/(\d{1,2})[^~〜]*[~〜].*?(\d{1,2})/(\d{1,2})',
+                    day_text
+                )
+
+                # 開始時刻を抽出（終了時刻を除く）
+                # 「9:30～(終11:00)」から9:30を取得
+                start_time_match = re.search(r'(\d{1,2}:\d{2})～', day_text)
+                start_time = start_time_match.group(1) if start_time_match else ""
+
+                year = datetime.now().year
+                if date_range_match:
+                    start_month = int(date_range_match.group(1))
+                    start_day = int(date_range_match.group(2))
+                    end_month = int(date_range_match.group(3))
+                    end_day = int(date_range_match.group(4))
+                    start_date = f"{year}-{start_month:02d}-{start_day:02d}"
+                    end_date = f"{year}-{end_month:02d}-{end_day:02d}"
+                else:
+                    start_date = datetime.now().strftime("%Y-%m-%d")
+                    end_date = start_date
+
                 schedules.append(MovieSchedule(
                     theater_name=self.theater_name,
-                    movie_title=movie_title,
-                    showtimes=showtimes
-                ))
-                
-        return schedules
-        
-    def _extract_showtimes_from_element(self, element) -> List[ShowtimeInfo]:
-        """要素からスケジュール情報抽出"""
-        showtimes = []
-        
-        # 日付と時間の組み合わせを検索
-        date_time_pairs = element.find_all("div", class_="date-time") or element.find_all("li")
-        
-        for pair in date_time_pairs:
-            # 日付
-            date_elem = pair.find("span", class_="date") or pair.find("div", class_="date")
-            date_text = self.safe_extract_text(date_elem)
-            
-            # 時刻
-            time_elems = pair.find_all("span", class_="time") or pair.find_all("div", class_="time")
-            times = [self.safe_extract_text(elem) for elem in time_elems if self.safe_extract_text(elem)]
-            
-            if date_text and times:
-                formatted_date = self._format_date(date_text)
-                
-                showtimes.append(ShowtimeInfo(
-                    date=formatted_date,
-                    times=times,
-                    screen="スクリーン1"
-                ))
-                
-        return showtimes
-        
-    def _extract_showtimes_from_text(self, text: str) -> List[ShowtimeInfo]:
-        """テキストからスケジュール情報抽出"""
-        showtimes = []
-        
-        # 日付と時間のパターンを検索
-        date_time_pattern = r"(\d{1,2}[/月]\d{1,2}[日]?)[^\d]*(\d{1,2}:\d{2})"
-        matches = re.findall(date_time_pattern, text)
-        
-        current_date = None
-        current_times = []
-        
-        for date_str, time_str in matches:
-            formatted_date = self._format_date(date_str)
-            
-            if current_date and current_date != formatted_date:
-                # 前の日付のデータを保存
-                if current_times:
-                    showtimes.append(ShowtimeInfo(
-                        date=current_date,
-                        times=current_times,
+                    movie_title=title,
+                    showtimes=[ShowtimeInfo(
+                        date=start_date,
+                        times=[start_time] if start_time else [],
                         screen="スクリーン1"
-                    ))
-                current_times = []
-                
-            current_date = formatted_date
-            current_times.append(time_str)
-            
-        # 最後のデータを保存
-        if current_date and current_times:
-            showtimes.append(ShowtimeInfo(
-                date=current_date,
-                times=current_times,
-                screen="スクリーン1"
-            ))
-            
-        return showtimes
-        
-    def _format_date(self, date_text: str) -> str:
-        """日付フォーマット変換"""
-        try:
-            # 様々な日付形式に対応
-            date_patterns = [
-                r"(\d{1,2})/(\d{1,2})",  # MM/DD
-                r"(\d{1,2})月(\d{1,2})日",  # MM月DD日
-                r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
-                r"(\d{1,2})\.(\d{1,2})",  # MM.DD
-            ]
-            
-            for pattern in date_patterns:
-                match = re.search(pattern, date_text)
-                if match:
-                    if len(match.groups()) == 2:
-                        month, day = match.groups()
-                        return f"2024-{int(month):02d}-{int(day):02d}"
-                    elif len(match.groups()) == 3:
-                        year, month, day = match.groups()
-                        return f"{year}-{int(month):02d}-{int(day):02d}"
-                        
-            return date_text
-            
-        except Exception:
-            return date_text
+                    )]
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting schedule info: {e}")
+                continue
+
+        return schedules

--- a/src/scraping/scrapers/shinjuku_musashino_scraper.py
+++ b/src/scraping/scrapers/shinjuku_musashino_scraper.py
@@ -11,361 +11,125 @@ from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class ShinjukuMusashinoScraper(BaseScraper):
     """新宿武蔵野館 スクレイパー"""
-    
+
     def __init__(self):
         super().__init__(
             theater_name="新宿武蔵野館",
             base_url="https://shinjuku.musashino-k.jp"
         )
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        soup = self.get_page(self.base_url)
-        if not soup:
-            soup = self.get_page_with_selenium(self.base_url)
-            
-        if not soup:
-            # 基本情報をハードコード
-            return TheaterInfo(
-                name=self.theater_name,
-                url=self.base_url,
-                address="東京都新宿区新宿3-27-10",
-                phone="03-3354-5670",
-                access="JR新宿駅東口より徒歩5分",
-                screens=2
-            )
-            
-        # ページから詳細情報を取得
-        address = "東京都新宿区新宿3-27-10"
-        phone = "03-3354-5670"
-        access = "JR新宿駅東口より徒歩5分"
-        
-        # 404エラーを避けるため、アクセスページは取得しない
-                
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
-            address=address,
-            phone=phone,
-            access=access,
+            address="東京都新宿区新宿3-27-10",
+            phone="03-3354-5670",
+            access="JR新宿駅東口より徒歩5分",
             screens=2
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
         movies = []
-        
-        # メインページから映画情報取得
         soup = self.get_page(self.base_url)
         if soup:
             movies.extend(self._extract_movies_from_page(soup))
-                
         return movies
-        
+
     def _extract_movies_from_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """ページから映画情報抽出"""
+        """ページから映画情報抽出
+        HTML構造: article.movies.flex-item > a(リンク) > div.description > div.label(上映期限) + タイトルテキスト
+        """
         movies = []
-        
-        # 新宿武蔵野館サイトから映画タイトルを抽出
-        # h4要素に映画タイトルが含まれている
-        h4_elements = soup.find_all("h4")
-        
-        movie_titles = []
-        for h4 in h4_elements:
-            title = h4.get_text().strip()
-            
-            # 映画タイトルらしいh4を特定
-            if (title and 
-                len(title) > 2 and 
-                len(title) < 100 and
-                # オンライン予約やニュースではないものを対象
-                not any(skip in title for skip in [
-                    '上映時間', 'オンライン予約', 'ニュース', 'アクセス',
-                    '劇場案内', '株主', '公式', 'はこちら', 'まで（予定）'
-                ]) and
-                # 日付パターンは除外
-                not re.match(r'^\d{4}\.\d{2}\.\d{2}', title) and
-                # 更新情報は除外  
-                not any(word in title for word in ['更新', '決定', '導入', '販売']) and
-                # 実際の映画らしいタイトル
-                (any(char in title for char in ['！', '？', '・']) or
-                 re.search(r'[ァ-ヴ]+', title) or
-                 re.search(r'[A-Za-z]{2,}', title) or
-                 # 日本語の映画タイトルらしいパターン
-                 len([c for c in title if ord(c) > 127]) > len(title) * 0.5)):
-                
-                # 重複チェック
-                if title not in movie_titles:
-                    movie_titles.append(title)
-        
-        # 観察されたタイトルを明示的に追加
-        known_movies = [
-            "「桐島です」",
-            "恋するリベラーチェ ４Ｋ",
-            "ＹＯＵＮＧ＆ＦＩＮＥ", 
-            "となりの宇宙人",
-            "テルマがゆく！９３歳のやさしいリベンジ",
-            "突然、君がいなくなって",
-            "中山教頭の人生テスト",
-            "年少日記",
-            "無名の人生",
-            "ロボット・ドリームズ"
-        ]
-        
-        body_text = soup.get_text()
-        for known_movie in known_movies:
-            if known_movie in body_text and known_movie not in movie_titles:
-                movie_titles.append(known_movie)
-        
-        # MovieInfoオブジェクトを作成
-        for title in movie_titles[:15]:  # 最大15作品
-            movies.append(MovieInfo(
-                title=title,
-                title_en=None,
-                director=None,
-                cast=[],
-                duration=None,
-                synopsis=None,
-                poster_url=None
-            ))
-                    
-        return movies
-        
-    def _extract_movie_from_element(self, element) -> Optional[MovieInfo]:
-        """要素から映画情報抽出"""
-        try:
-            # タイトル
-            title_elem = (element.find("h2") or element.find("h3") or element.find("h4") or
-                         element.find("div", class_="title") or element.find("a", class_="movie-title"))
-            title = self.safe_extract_text(title_elem)
-            
-            if not title:
-                return None
-                
-            # 英語タイトル
-            title_en_elem = element.find("p", class_="title-en") or element.find("div", class_="title-en")
-            title_en = self.safe_extract_text(title_en_elem)
-            
-            # 映画情報から詳細を抽出
-            info_elem = element.find("div", class_="movie-info") or element.find("div", class_="film-details")
-            info_text = self.safe_extract_text(info_elem) if info_elem else element.get_text()
-            
-            director = ""
-            cast = []
-            genre = ""
-            synopsis = ""
-            duration = None
-            
-            if info_text:
-                # 監督情報
-                director_patterns = [
-                    r"監督[：:]([^\n/]+)",
-                    r"脚本・監督[：:]([^\n/]+)",
-                    r"Director[：:]([^\n/]+)"
-                ]
-                
-                for pattern in director_patterns:
-                    match = re.search(pattern, info_text)
-                    if match:
-                        director = match.group(1).strip()
-                        break
-                        
-                # 出演者情報
-                cast_patterns = [
-                    r"出演[：:]([^\n/]+)",
-                    r"キャスト[：:]([^\n/]+)",
-                    r"Cast[：:]([^\n/]+)"
-                ]
-                
-                for pattern in cast_patterns:
-                    match = re.search(pattern, info_text)
-                    if match:
-                        cast_text = match.group(1).strip()
-                        cast = [c.strip() for c in re.split(r"[,、]", cast_text) if c.strip()]
-                        break
-                        
-                # 上映時間
-                duration_match = re.search(r"(\d+)分", info_text)
-                if duration_match:
-                    duration = int(duration_match.group(1))
-                    
-                # ジャンル情報
-                genre_patterns = [
-                    r"ジャンル[：:]([^\n/]+)",
-                    r"カテゴリー[：:]([^\n/]+)"
-                ]
-                
-                for pattern in genre_patterns:
-                    match = re.search(pattern, info_text)
-                    if match:
-                        genre = match.group(1).strip()
-                        break
-                        
-            # あらすじ
-            synopsis_elem = element.find("div", class_="synopsis") or element.find("p", class_="description")
-            if synopsis_elem:
-                synopsis = self.safe_extract_text(synopsis_elem)
-            elif info_text and len(info_text) > 100:
-                synopsis = info_text[:200] + "..." if len(info_text) > 200 else info_text
-                
-            # ポスター画像
-            poster_elem = element.find("img")
-            poster_url = ""
-            if poster_elem:
-                poster_url = self.safe_extract_attr(poster_elem, "src")
-                if poster_url and not poster_url.startswith("http"):
-                    if poster_url.startswith("//"):
-                        poster_url = f"https:{poster_url}"
-                    else:
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
-            return MovieInfo(
-                title=title,
-                title_en=title_en if title_en else None,
-                director=director if director else None,
-                cast=cast,
-                genre=genre if genre else None,
-                duration=duration,
-                synopsis=synopsis if synopsis else None,
-                poster_url=poster_url if poster_url else None
-            )
-            
-        except Exception as e:
-            self.logger.error(f"Error extracting movie info: {e}")
-            return None
-            
-    def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得"""
-        schedules = []
-        
-        # スケジュールページを取得
-        schedule_soup = self.get_page(f"{self.base_url}/schedule/") or self.get_page_with_selenium(f"{self.base_url}/schedule/")
-        if schedule_soup:
-            schedules.extend(self._extract_schedules_from_page(schedule_soup))
-            
-        # メインページからもスケジュール情報を確認
-        main_soup = self.get_page(self.base_url) or self.get_page_with_selenium(self.base_url)
-        if main_soup:
-            schedules.extend(self._extract_schedules_from_page(main_soup))
-            
-        return schedules
-        
-    def _extract_schedules_from_page(self, soup: BeautifulSoup) -> List[MovieSchedule]:
-        """ページからスケジュール情報抽出"""
-        schedules = []
-        
-        # スケジュール情報を含む要素を検索
-        schedule_elements = (soup.find_all("div", class_="schedule") or 
-                           soup.find_all("table", class_="schedule") or
-                           soup.find_all("div", class_="timetable") or
-                           soup.find_all("section", class_="schedule-section"))
-        
-        # スケジュールテーブルも確認
-        schedule_tables = soup.find_all("table")
-        for table in schedule_tables:
-            if "schedule" in table.get("class", []) or "timetable" in table.get("class", []):
-                schedule_elements.append(table)
-                
-        for element in schedule_elements:
+        seen_titles = set()
+
+        for article in soup.find_all("article", class_="movies"):
             try:
-                # 映画タイトル
-                title_elem = (element.find("h2") or element.find("h3") or 
-                             element.find("caption") or element.find("div", class_="movie-title"))
-                movie_title = self.safe_extract_text(title_elem)
-                
-                if not movie_title:
+                text = article.get_text(separator="\n", strip=True)
+                lines = [l.strip() for l in text.split("\n") if l.strip()]
+
+                # ラベル（上映期限テキスト）を除去してタイトルを取得
+                # 「X月X旬まで（予定）」「X月XH（曜）まで」のような行を除く
+                title = None
+                for line in lines:
+                    if re.search(r'まで|上映期限|予定', line):
+                        continue
+                    if len(line) > 1:
+                        title = line
+                        break
+
+                if not title or title in seen_titles:
                     continue
-                    
-                # 上映時間情報
-                showtimes = self._extract_showtimes_from_element(element)
-                
-                if showtimes:
-                    schedules.append(MovieSchedule(
-                        theater_name=self.theater_name,
-                        movie_title=movie_title,
-                        showtimes=showtimes
-                    ))
-                    
+                seen_titles.add(title)
+
+                # 映画詳細ページURL
+                link = article.find("a")
+                movie_url = None
+                if link:
+                    href = link.get("href", "")
+                    if href:
+                        movie_url = href if href.startswith("http") else f"{self.base_url}{href}"
+
+                # ポスター画像（bgimgスタイルから取得）
+                poster_url = None
+                bgimg = article.find("div", class_="bgimg")
+                if bgimg:
+                    style = bgimg.get("style", "")
+                    img_match = re.search(r"url\(['\"]?([^'\"]+)['\"]?\)", str(style))
+                    if img_match:
+                        poster_url = img_match.group(1)
+
+                movies.append(MovieInfo(
+                    title=title,
+                    poster_url=poster_url
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting movie info: {e}")
+                continue
+
+        return movies
+
+    def get_schedules(self) -> List[MovieSchedule]:
+        """スケジュール情報取得
+        新宿武蔵野館の詳細な上映時刻は外部システム(cineticket.jp)で管理されているため、
+        このサイトから取得できる情報（映画タイトル・上映期限）のみを返す。
+        """
+        schedules = []
+        soup = self.get_page(self.base_url)
+        if not soup:
+            return schedules
+
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        for article in soup.find_all("article", class_="movies"):
+            try:
+                text = article.get_text(separator="\n", strip=True)
+                lines = [l.strip() for l in text.split("\n") if l.strip()]
+
+                title = None
+                for line in lines:
+                    if re.search(r'まで|上映期限|予定', line):
+                        continue
+                    if len(line) > 1:
+                        title = line
+                        break
+
+                if not title:
+                    continue
+
+                # 上映時刻はページから取得不可のため空リストで記録
+                schedules.append(MovieSchedule(
+                    theater_name=self.theater_name,
+                    movie_title=title,
+                    showtimes=[ShowtimeInfo(
+                        date=today,
+                        times=[],
+                        screen="スクリーン"
+                    )]
+                ))
+
             except Exception as e:
                 self.logger.error(f"Error extracting schedule info: {e}")
                 continue
-                
+
         return schedules
-        
-    def _extract_showtimes_from_element(self, element) -> List[ShowtimeInfo]:
-        """要素からスケジュール情報抽出"""
-        showtimes = []
-        
-        # テーブル形式のスケジュール
-        if element.name == "table":
-            rows = element.find_all("tr")
-            for row in rows:
-                cells = row.find_all(["td", "th"])
-                if len(cells) >= 2:
-                    # 日付セル
-                    date_text = self.safe_extract_text(cells[0])
-                    # 時間セル
-                    time_cells = cells[1:]
-                    times = [self.safe_extract_text(cell) for cell in time_cells if self.safe_extract_text(cell)]
-                    
-                    if date_text and times:
-                        formatted_date = self._format_date(date_text)
-                        if formatted_date:
-                            showtimes.append(ShowtimeInfo(
-                                date=formatted_date,
-                                times=times,
-                                screen="スクリーン1"
-                            ))
-        else:
-            # div形式のスケジュール
-            date_blocks = element.find_all("div", class_="date-block") or element.find_all("div", class_="schedule-day")
-            
-            for block in date_blocks:
-                # 日付
-                date_elem = block.find("div", class_="date") or block.find("span", class_="date")
-                date_text = self.safe_extract_text(date_elem)
-                
-                # 時刻
-                time_elems = block.find_all("span", class_="time") or block.find_all("div", class_="time")
-                times = [self.safe_extract_text(elem) for elem in time_elems if self.safe_extract_text(elem)]
-                
-                # スクリーン情報
-                screen_elem = block.find("span", class_="screen") or block.find("div", class_="screen")
-                screen = self.safe_extract_text(screen_elem) if screen_elem else "スクリーン1"
-                
-                if date_text and times:
-                    formatted_date = self._format_date(date_text)
-                    if formatted_date:
-                        showtimes.append(ShowtimeInfo(
-                            date=formatted_date,
-                            times=times,
-                            screen=screen
-                        ))
-                        
-        return showtimes
-        
-    def _format_date(self, date_text: str) -> str:
-        """日付フォーマット変換"""
-        try:
-            # 様々な日付形式に対応
-            date_patterns = [
-                r"(\d{1,2})/(\d{1,2})",  # MM/DD
-                r"(\d{1,2})月(\d{1,2})日",  # MM月DD日
-                r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
-                r"(\d{1,2})\.(\d{1,2})",  # MM.DD
-            ]
-            
-            for pattern in date_patterns:
-                match = re.search(pattern, date_text)
-                if match:
-                    if len(match.groups()) == 2:
-                        month, day = match.groups()
-                        return f"2024-{int(month):02d}-{int(day):02d}"
-                    elif len(match.groups()) == 3:
-                        year, month, day = match.groups()
-                        return f"{year}-{int(month):02d}-{int(day):02d}"
-                        
-            return ""
-            
-        except Exception:
-            return ""

--- a/src/scraping/scrapers/waseda_shochiku_scraper.py
+++ b/src/scraping/scrapers/waseda_shochiku_scraper.py
@@ -11,16 +11,14 @@ from ..models import MovieInfo, ShowtimeInfo, MovieSchedule, TheaterInfo
 
 class WasedaShochikuScraper(BaseScraper):
     """早稲田松竹 スクレイパー"""
-    
+
     def __init__(self):
         super().__init__(
             theater_name="早稲田松竹",
-            base_url="http://wasedashochiku.co.jp"
+            base_url="https://wasedashochiku.co.jp"
         )
-        
+
     def get_theater_info(self) -> TheaterInfo:
-        """映画館情報取得"""
-        # 基本情報を返す（シンプル化）
         return TheaterInfo(
             name=self.theater_name,
             url=self.base_url,
@@ -29,360 +27,188 @@ class WasedaShochikuScraper(BaseScraper):
             access="JR山手線・西武新宿線・東西線高田馬場駅より徒歩3分",
             screens=1
         )
-        
+
     def get_movies(self) -> List[MovieInfo]:
-        """映画情報取得"""
+        """映画情報取得
+        トップページのh3タグにスケジュールページリンクがあり、
+        各スケジュールページのh3.sakuhin-titleに映画タイトルが記載されている。
+        """
         movies = []
-        
-        # メインページから映画情報取得（requestsを使用）
+        seen_titles = set()
+
+        schedule_links = self._get_schedule_links()
+        for link in schedule_links:
+            try:
+                soup = self.get_page(link)
+                if not soup:
+                    continue
+                for movie in self._extract_movies_from_schedule_page(soup):
+                    if movie.title not in seen_titles:
+                        seen_titles.add(movie.title)
+                        movies.append(movie)
+                self.delay(0.5)
+            except Exception as e:
+                self.logger.error(f"Error fetching schedule page {link}: {e}")
+
+        return movies
+
+    def _get_schedule_links(self) -> List[str]:
+        """トップページからスケジュールページのURLを収集"""
         soup = self.get_page(self.base_url)
-        if soup:
-            movies.extend(self._extract_movies_from_page(soup))
-                
-        return movies
-        
-    def _extract_movies_from_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
-        """ページから映画情報抽出"""
+        if not soup:
+            return []
+
+        links = []
+        seen = set()
+        for h3 in soup.find_all("h3"):
+            a = h3.find("a")
+            if not a:
+                continue
+            href = a.get("href", "")
+            if "/archives/schedule/" in href and href not in seen:
+                seen.add(href)
+                links.append(href)
+
+        return links
+
+    def _extract_movies_from_schedule_page(self, soup: BeautifulSoup) -> List[MovieInfo]:
+        """スケジュール詳細ページから映画情報を抽出
+        HTML構造:
+          div.sakuhinjoho-box > h3.sakuhin-title(タイトル + span英題) + div.sakuhin-time(時刻)
+        """
         movies = []
-        
-        # 早稲田松竹サイトから映画タイトルを抽出
-        body_text = soup.get_text()
-        
-        # 実際のサイトから観察した映画タイトルパターン
-        lines = body_text.split('\n')
-        movie_titles = []
-        
-        for line in lines:
-            line = line.strip()
-            # 映画タイトルらしい行を特定（名画座特有のパターンを考慮）
-            if (line and 
-                len(line) > 3 and 
-                len(line) < 50 and
-                not any(skip in line for skip in [
-                    'official', 'web', 'site', '名画座', '高田馬場',
-                    '年', '月', '日', '時', '分', ':', 
-                    'http', 'www', '.com', '@'
-                ]) and
-                not line.isdigit() and
-                not re.match(r'^\d{1,2}[/:\-]\d{1,2}', line) and
-                # 特殊文字や外国語タイトルを検出
-                (any(char in line for char in ['＋', '＆', '・']) or
-                 re.search(r'[ァ-ヴ]+', line) or
-                 re.search(r'[A-Za-z]{3,}', line) or
-                 len([c for c in line if ord(c) > 127]) > len(line) * 0.3)):  # 日本語文字が多い
-                
-                # 重複チェック
-                if line not in movie_titles:
-                    movie_titles.append(line)
-        
-        # 観察されたタイトルパターンも明示的に追加
-        known_patterns = [
-            "惑星ソラリス",
-            "ラ・ジュテ",
-            "ジュ・テーム、ジュ・テーム"
-        ]
-        
-        for pattern in known_patterns:
-            if pattern in body_text and pattern not in movie_titles:
-                movie_titles.append(pattern)
-        
-        # 二本立て映画のパターンを検出
-        double_feature_patterns = re.findall(r'([^\n]+)\s*\+\s*([^\n]+)', body_text)
-        for pattern in double_feature_patterns:
-            for title in pattern:
-                title = title.strip()
-                if title and len(title) > 2 and title not in movie_titles:
-                    movie_titles.append(title)
-        
-        # MovieInfoオブジェクトを作成
-        for title in movie_titles[:10]:  # 最大10作品
-            movies.append(MovieInfo(
-                title=title,
-                title_en=None,
-                director=None,
-                cast=[],
-                duration=None,
-                synopsis=None,
-                poster_url=None
-            ))
-                    
+
+        for box in soup.find_all("div", class_="sakuhinjoho-box"):
+            try:
+                # h3.sakuhin-titleにタイトル（span内に英語タイトル）
+                title_elem = box.find("h3", class_="sakuhin-title")
+                if not title_elem:
+                    continue
+
+                en_span = title_elem.find("span")
+                title_en = en_span.get_text(strip=True) if en_span else None
+                if en_span:
+                    en_span.decompose()
+
+                title = title_elem.get_text(separator="", strip=True)
+                if not title:
+                    continue
+
+                # ポスター画像
+                poster_url = None
+                img = box.find("img")
+                if img:
+                    src = img.get("src", "")
+                    if src:
+                        poster_url = src if src.startswith("http") else f"{self.base_url}{src}"
+
+                # 監督・上映時間等の情報テキスト
+                director = None
+                duration = None
+                info_elem = box.find("div", class_="intro-textarea")
+                if info_elem:
+                    info_text = info_elem.get_text()
+                    director_match = re.search(r'監督[：:]\s*([^\n/]+)', info_text)
+                    if director_match:
+                        director = director_match.group(1).strip()
+                    duration_match = re.search(r'(\d+)分', info_text)
+                    if duration_match:
+                        duration = int(duration_match.group(1))
+
+                movies.append(MovieInfo(
+                    title=title,
+                    title_en=title_en,
+                    director=director,
+                    duration=duration,
+                    poster_url=poster_url
+                ))
+
+            except Exception as e:
+                self.logger.error(f"Error extracting movie from schedule page: {e}")
+                continue
+
         return movies
-        
-    def _extract_movie_from_element(self, element) -> Optional[MovieInfo]:
-        """要素から映画情報抽出"""
-        try:
-            # タイトル
-            title_elem = (element.find("h1") or element.find("h2") or element.find("h3") or
-                         element.find("div", class_="title") or element.find("a", class_="post-title"))
-            title = self.safe_extract_text(title_elem)
-            
-            if not title:
-                return None
-                
-            # 名画座特有の二本立て形式を考慮
-            if "＆" in title or "+" in title:
-                # 二本立ての場合は分割
-                titles = re.split(r"[＆+]", title)
-                if len(titles) > 1:
-                    title = titles[0].strip()
-                    
-            # 英語タイトル
-            title_en_elem = element.find("p", class_="title-en") or element.find("div", class_="title-en")
-            title_en = self.safe_extract_text(title_en_elem)
-            
-            # 映画情報テキストから詳細を抽出
-            content_elem = element.find("div", class_="content") or element.find("div", class_="post-content")
-            content = self.safe_extract_text(content_elem)
-            
-            director = ""
-            cast = []
-            genre = ""
-            synopsis = ""
-            duration = None
-            
-            if content:
-                # 監督情報
-                director_patterns = [
-                    r"監督[：:]([^\n/]+)",
-                    r"脚本・監督[：:]([^\n/]+)",
-                    r"Director[：:]([^\n/]+)"
-                ]
-                
-                for pattern in director_patterns:
-                    match = re.search(pattern, content)
-                    if match:
-                        director = match.group(1).strip()
-                        break
-                        
-                # 出演者情報
-                cast_patterns = [
-                    r"出演[：:]([^\n/]+)",
-                    r"キャスト[：:]([^\n/]+)",
-                    r"Cast[：:]([^\n/]+)"
-                ]
-                
-                for pattern in cast_patterns:
-                    match = re.search(pattern, content)
-                    if match:
-                        cast_text = match.group(1).strip()
-                        cast = [c.strip() for c in re.split(r"[,、]", cast_text) if c.strip()]
-                        break
-                        
-                # 上映時間
-                duration_match = re.search(r"(\d+)分", content)
-                if duration_match:
-                    duration = int(duration_match.group(1))
-                    
-                # 製作年
-                year_match = re.search(r"(\d{4})年", content)
-                if year_match:
-                    year = year_match.group(1)
-                    
-                # ジャンル情報
-                genre_patterns = [
-                    r"ジャンル[：:]([^\n/]+)",
-                    r"カテゴリー[：:]([^\n/]+)"
-                ]
-                
-                for pattern in genre_patterns:
-                    match = re.search(pattern, content)
-                    if match:
-                        genre = match.group(1).strip()
-                        break
-                        
-                # あらすじ（内容の一部を使用）
-                synopsis = content[:200] + "..." if len(content) > 200 else content
-                
-            # ポスター画像
-            poster_elem = element.find("img")
-            poster_url = ""
-            if poster_elem:
-                poster_url = self.safe_extract_attr(poster_elem, "src")
-                if poster_url and not poster_url.startswith("http"):
-                    if poster_url.startswith("//"):
-                        poster_url = f"http:{poster_url}"
-                    else:
-                        poster_url = f"{self.base_url}{poster_url}"
-                        
-            return MovieInfo(
-                title=title,
-                title_en=title_en if title_en else None,
-                director=director if director else None,
-                cast=cast,
-                genre=genre if genre else None,
-                duration=duration,
-                synopsis=synopsis if synopsis else None,
-                poster_url=poster_url if poster_url else None
-            )
-            
-        except Exception as e:
-            self.logger.error(f"Error extracting movie info: {e}")
-            return None
-            
+
     def get_schedules(self) -> List[MovieSchedule]:
-        """スケジュール情報取得"""
+        """スケジュール情報取得
+        各スケジュールページのdiv.sakuhin-timeに時刻情報がある。
+        """
         schedules = []
-        
-        # メインページからスケジュール情報取得
-        soup = self.get_page(self.base_url)
-        if soup:
-            schedules.extend(self._extract_schedules_from_page(soup))
-            
-        return schedules
-        
-    def _extract_schedules_from_page(self, soup: BeautifulSoup) -> List[MovieSchedule]:
-        """ページからスケジュール情報抽出"""
-        schedules = []
-        
-        # 早稲田松竹サイトのスケジュール解析
-        body_text = soup.get_text()
-        
-        # 観察されたスケジュールパターン:
-        # "7/5(土)･7(月)･9(水)･11(金)惑星ソラリス10:4016:15ラ・ジュテ + ジュ・テーム、ジュ・テーム1"
-        
-        # スケジュールパターンを解析
-        schedule_pattern = r'(\d{1,2}/\d{1,2}\([^)]+\)[^a-zA-Z\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]*)([\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAFA-Za-z\s\+\・]+)(\d{1,2}:\d{2}[^\d]*\d{1,2}:\d{2})?'
-        
-        matches = re.findall(schedule_pattern, body_text)
-        
-        for match in matches:
-            date_info = match[0]
-            movie_info = match[1]
-            time_info = match[2] if len(match) > 2 else ""
-            
-            # 日付から最初の日付を抽出
-            date_match = re.search(r'(\d{1,2})/(\d{1,2})', date_info)
-            if date_match:
-                month, day = date_match.groups()
-                formatted_date = f"2025-{int(month):02d}-{int(day):02d}"
-                
-                # 時間を抽出
-                times = re.findall(r'(\d{1,2}:\d{2})', time_info) if time_info else ["14:30", "19:00"]
-                
-                # 映画タイトルを分離（二本立ての場合）
-                if "+" in movie_info:
-                    # 二本立て
-                    titles = [t.strip() for t in movie_info.split("+")]
-                    for title in titles:
-                        if title and len(title) > 2:
-                            schedules.append(MovieSchedule(
-                                theater_name=self.theater_name,
-                                movie_title=title,
-                                showtimes=[ShowtimeInfo(
-                                    date=formatted_date,
-                                    times=times,
-                                    screen="スクリーン1"
-                                )]
-                            ))
-                else:
-                    # 単独作品
-                    movie_title = movie_info.strip()
-                    if movie_title and len(movie_title) > 2:
-                        schedules.append(MovieSchedule(
-                            theater_name=self.theater_name,
-                            movie_title=movie_title,
-                            showtimes=[ShowtimeInfo(
-                                date=formatted_date,
-                                times=times,
-                                screen="スクリーン1"
-                            )]
-                        ))
-        
-        # フォールバック: より簡単なパターン検索
-        if not schedules:
-            # 既知の映画タイトルを検索
-            known_movies = ["惑星ソラリス", "ラ・ジュテ", "ジュ・テーム、ジュ・テーム"]
-            
-            for movie in known_movies:
-                if movie in body_text:
-                    # 近くの時間情報を検索
-                    movie_index = body_text.find(movie)
-                    surrounding_text = body_text[max(0, movie_index-50):movie_index+100]
-                    
-                    # 時間パターンを検索
-                    times = re.findall(r'(\d{1,2}:\d{2})', surrounding_text)
-                    if not times:
-                        times = ["14:30", "19:00"]
-                    
-                    # 日付パターンを検索
-                    dates = re.findall(r'(\d{1,2})/(\d{1,2})', surrounding_text)
-                    if dates:
-                        month, day = dates[0]
-                        formatted_date = f"2025-{int(month):02d}-{int(day):02d}"
-                    else:
-                        # デフォルト日付
-                        formatted_date = "2025-07-05"
-                    
-                    schedules.append(MovieSchedule(
-                        theater_name=self.theater_name,
-                        movie_title=movie,
-                        showtimes=[ShowtimeInfo(
-                            date=formatted_date,
+
+        schedule_links = self._get_schedule_links()
+        for link in schedule_links:
+            try:
+                soup = self.get_page(link)
+                if not soup:
+                    continue
+
+                date_range = self._extract_date_range_from_page(soup)
+
+                for box in soup.find_all("div", class_="sakuhinjoho-box"):
+                    try:
+                        title_elem = box.find("h3", class_="sakuhin-title")
+                        if not title_elem:
+                            continue
+
+                        en_span = title_elem.find("span")
+                        if en_span:
+                            en_span.decompose()
+                        movie_title = title_elem.get_text(separator="", strip=True)
+                        if not movie_title:
+                            continue
+
+                        # div.sakuhin-time から時刻取得
+                        # 形式: 「開映時間　10:30／15:15／20:00(～終映21:35)」
+                        time_elem = box.find("div", class_="sakuhin-time")
+                        times = []
+                        if time_elem:
+                            time_text = time_elem.get_text()
+                            # 開映時刻のみ抽出（「／」区切り）
+                            times = re.findall(r'(\d{1,2}:\d{2})', time_text)
+                            # 終映時刻を除外（直前に「終映」や「終」が来るもの）
+                            clean_text = time_text
+                            end_times = re.findall(r'(?:終映|終)\s*(\d{1,2}:\d{2})', clean_text)
+                            times = [t for t in times if t not in end_times]
+
+                        showtimes = [ShowtimeInfo(
+                            date=date_range["start"] if date_range else datetime.now().strftime("%Y-%m-%d"),
                             times=times,
                             screen="スクリーン1"
                         )]
-                    ))
-                
+
+                        schedules.append(MovieSchedule(
+                            theater_name=self.theater_name,
+                            movie_title=movie_title,
+                            showtimes=showtimes
+                        ))
+
+                    except Exception as e:
+                        self.logger.error(f"Error extracting schedule from box: {e}")
+                        continue
+
+                self.delay(0.5)
+
+            except Exception as e:
+                self.logger.error(f"Error fetching schedule page {link}: {e}")
+
         return schedules
-        
-    def _extract_showtimes_from_element(self, element) -> List[ShowtimeInfo]:
-        """要素からスケジュール情報抽出"""
-        showtimes = []
-        
-        content = element.get_text()
-        
-        # 上映時間のパターンを検索
-        time_patterns = [
-            r"(\d{1,2}:\d{2})",
-            r"(\d{1,2}時\d{2}分)",
-            r"(\d{1,2}):\d{2}[～〜-](\d{1,2}:\d{2})"
-        ]
-        
-        times = []
-        for pattern in time_patterns:
-            matches = re.findall(pattern, content)
-            for match in matches:
-                if isinstance(match, tuple):
-                    times.extend(match)
+
+    def _extract_date_range_from_page(self, soup: BeautifulSoup) -> Optional[dict]:
+        """ページから上映期間を抽出
+        トップページのh3に「6/13.sat - 6/16.tue」形式で日程が記載されている。
+        """
+        for tag in soup.find_all(["h1", "h2", "h3"]):
+            text = tag.get_text()
+            matches = re.findall(r'(\d{1,2})[/\.](\d{1,2})', text)
+            if matches:
+                year = datetime.now().year
+                start_month, start_day = int(matches[0][0]), int(matches[0][1])
+                start_date = f"{year}-{start_month:02d}-{start_day:02d}"
+                if len(matches) >= 2:
+                    end_month, end_day = int(matches[1][0]), int(matches[1][1])
+                    end_date = f"{year}-{end_month:02d}-{end_day:02d}"
                 else:
-                    times.append(match)
-                    
-        # 日付パターンを検索
-        date_patterns = [
-            r"(\d{1,2})/(\d{1,2})",
-            r"(\d{1,2})月(\d{1,2})日",
-            r"(\d{4})-(\d{1,2})-(\d{1,2})"
-        ]
-        
-        dates = []
-        for pattern in date_patterns:
-            matches = re.findall(pattern, content)
-            for match in matches:
-                if len(match) == 2:
-                    month, day = match
-                    formatted_date = f"2024-{int(month):02d}-{int(day):02d}"
-                    dates.append(formatted_date)
-                elif len(match) == 3:
-                    year, month, day = match
-                    formatted_date = f"{year}-{int(month):02d}-{int(day):02d}"
-                    dates.append(formatted_date)
-                    
-        # 上映時間が見つからない場合はデフォルト時間を使用
-        if not times:
-            times = ["14:30", "19:00"]  # 名画座の一般的な上映時間
-            
-        # 日付が見つからない場合は今日の日付を使用
-        if not dates:
-            today = datetime.now()
-            dates = [today.strftime("%Y-%m-%d")]
-            
-        # 各日付に対して上映時間を設定
-        for date in dates:
-            if times:
-                showtimes.append(ShowtimeInfo(
-                    date=date,
-                    times=times,
-                    screen="スクリーン1"
-                ))
-                
-        return showtimes
+                    end_date = start_date
+                return {"start": start_date, "end": end_date}
+
+        return None


### PR DESCRIPTION
## Summary

- 全6映画館のHPに実際にアクセスしてHTML構造を調査し、スクレイパーを修正
- `scrape_with_json.py` に未登録だったユーロスペース・ポレポレ東中野を追加
- 全6館で合計37本の映画を正常に取得できることを確認済み

## 変更内容

| 映画館 | 修正内容 |
|--------|---------|
| ケイズシネマ | h3タグで直接タイトル取得 |
| 下高井戸シネマ | li.float > span.eiga-title / span.day を使用 |
| 早稲田松竹 | https URL、sakuhinjoho-box + h3.sakuhin-title を使用 |
| 新宿武蔵野館 | article.movies.flex-item から取得 |
| ユーロスペース | http に変更、div.item / div.scrolltable を使用 |
| ポレポレ東中野 | Selenium使用、div.movie-schedule-info.flex-row を使用 |

## Test plan

- [x] 各スクレイパー単体でのデータ取得確認
- [x] `scrape_with_json.py all` で全6館・37本取得・JSON出力確認